### PR TITLE
[Readme] Update readme with example and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,49 @@ This code is based off of code from [egeriis/zipcelx](https://github.com/egeriis
 If you're looking for advanced functionality, [js-xlsx](https://github.com/SheetJS/js-xlsx) is a solid choice.
 
 ## Table of contents
-1. [Examples and How to Use](https://github.com/elliotstoner/xljsx-lite-examples/)
-2. [Contributing](https://github.com/elliotstoner/xljsx-lite/wiki/Contributing)
+1. [Installation](#installation)
+2. [Usage](#usage)
+3. [Examples](https://github.com/elliotstoner/xljsx-lite-examples/)
+4. [Contributing](https://github.com/elliotstoner/xljsx-lite/wiki/Contributing)
+5. [Issues](#issues)
+
+## Installation
+
+**Install via NPM**
+
+```
+npm i xljsx-lite --save
+```
+
+**Use standalone**
+
+Download and include `lib/standalone.js` in your project. This will expose a global `xljsxLite` function you can use to create and download spreadsheets.
+
+
+## Usage
+
+```js
+import { xljsxLite } from 'xljsx-lite';
+
+const config = {
+  filename: 'example-spreadsheet', // output filename, excluding extension
+  sheets: [
+    {
+      sheetname: 'sheet1',
+      data: [
+        ['Test', 'Data', 'Row 2'], // Each array in 'data' represents a row
+        ['More', 'Data', 'Row 2'],
+      ]
+    }
+  ]
+}
+
+// Generate spreadsheet and trigger download
+await xljsxLite(config)
+```
+
+For more examples, check out the [example repo](https://github.com/elliotstoner/xljsx-lite-examples/)
+
 
 ## Issues
 If you happen to come across a defect, please report them here: [Issue tracker](https://github.com/elliotstoner/xljsx-lite/issues)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const config = {
 await xljsxLite(config)
 ```
 
-For more examples, check out the [example repo](https://github.com/elliotstoner/xljsx-lite-examples/)
+For more examples, check out the [example repo.](https://github.com/elliotstoner/xljsx-lite-examples/)
 
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const config = {
     {
       sheetname: 'sheet1',
       data: [
-        ['Test', 'Data', 'Row 2'], // Each array in 'data' represents a row
+        ['Test', 'Data', 'Row 1'], // Each array in 'data' represents a row
         ['More', 'Data', 'Row 2'],
       ]
     }


### PR DESCRIPTION
The old package exported the `xlsx` function as the default export, but this version exports it as a named export (which is a breaking change). Adding an example of installation and how to import will help existing users upgrade easier, and will help new users get up and running faster.